### PR TITLE
Bugfix(es)

### DIFF
--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -102,7 +102,7 @@ PyArray_SetBaseObject(PyArrayObject *arr, PyObject *obj)
      * its own data.
      */
     while (PyArray_Check(obj) && (PyObject *)arr != obj) {
-        PyArrayObject *obj_arr = (PyArrayObject *)arr;
+        PyArrayObject *obj_arr = (PyArrayObject *)obj;
         PyObject *tmp;
 
         /* If this array owns its own data, stop collapsing */

--- a/numpy/core/tests/test_maskna.py
+++ b/numpy/core/tests/test_maskna.py
@@ -481,7 +481,7 @@ def test_array_maskna_array_function_1D():
 
     # Should produce a view with an owned mask with 'ownmaskna=True'
     c = np.array(b_view, copy=False, ownmaskna=True)
-    assert_(c.base is b_view)
+    assert_(c.base is b_view.base)
     assert_(c.flags.ownmaskna)
     assert_(not (c is b_view))
 


### PR DESCRIPTION
Hi Mark, in the process of hunting down a reference leak, I found a bug in PyArray_SetBaseObject which didn't properly find the base object in a loop (strange that it worked nonetheless, because it could have let to infinite looping.. I think?).

I tested the new numpy master against my own code. Somehow, the process keeps hogging memory in a certain case, but valgrind claims it is still reachable.. I haven't yet been able to pinpoint the cause or make a simple test case. When I know more, I'll update the pull request.
